### PR TITLE
Deploy by name and env

### DIFF
--- a/bamboo/bamboo_deployer.go
+++ b/bamboo/bamboo_deployer.go
@@ -68,8 +68,8 @@ func (d *deployer) selectProject(projectName string) (*project, error) {
 		return nil, fmt.Errorf("project list is empty")
 	}
 
-	filtered := filterProjects(projects, func(project) bool {
-		return true
+	filtered := filterProjects(projects, func(theProject project) bool {
+		return theProject.Name == projectName
 	})
 
 	if len(filtered) == 0 {
@@ -78,7 +78,7 @@ func (d *deployer) selectProject(projectName string) (*project, error) {
 		return nil, fmt.Errorf("More then 1 Project named %s found", projectName)
 	}
 
-	return &projects[0], nil
+	return &filtered[0], nil
 }
 
 func (d *deployer) Deploy(projectName, environmentName string) error {

--- a/bamboo/bamboo_deployer.go
+++ b/bamboo/bamboo_deployer.go
@@ -58,6 +58,14 @@ func filterProjects(vs []project, f func(project) bool) []project {
 	return vsf
 }
 
+func extractProjectNames(projects []project) []string {
+	names := make([]string, 0)
+	for _, project := range projects {
+		names = append(names, project.Name)
+	}
+	return names
+}
+
 func (d *deployer) selectProject(projectName string) (*project, error) {
 	projects, err := d.listProjects()
 	if err != nil {
@@ -75,9 +83,9 @@ func (d *deployer) selectProject(projectName string) (*project, error) {
 	})
 
 	if len(filtered) == 0 {
-		return nil, fmt.Errorf("No Project named %s found (searched %d Projects)", projectName, len(projects))
+		return nil, fmt.Errorf("No Project starting with %s found (searched %d Projects)", projectName, len(projects))
 	} else if len(filtered) > 1 {
-		return nil, fmt.Errorf("More then 1 Project named %s found", projectName)
+		return nil, fmt.Errorf("More then 1 Project starting with %s found: %s", projectName, strings.Join(extractProjectNames(filtered), ", "))
 	}
 
 	return &filtered[0], nil

--- a/bamboo/bamboo_deployer.go
+++ b/bamboo/bamboo_deployer.go
@@ -14,7 +14,7 @@ type executeRequest func(req *http.Request) (resp *http.Response, err error)
 
 // Deployer can trigger a bamboo deployment
 type Deployer interface {
-	Deploy(number int) error
+	Deploy(project, environment string) error
 }
 
 type deployer struct {
@@ -46,7 +46,7 @@ func (d *deployer) header() http.Header {
 	return h
 }
 
-func (d *deployer) Deploy(number int) error {
+func (d *deployer) Deploy(projectName, environmentName string) error {
 	glog.V(4).Infof("deploy to url: %v with user: %v and pw-length: %d", d.bambooUrl, d.bambooUsername, len(d.bambooPassword))
 	projects, err := d.listProjects()
 	if err != nil {

--- a/bamboo/bamboo_deployer.go
+++ b/bamboo/bamboo_deployer.go
@@ -101,7 +101,7 @@ func filterEnvironments(vs []environment, f func(environment) bool) []environmen
 	return vsf
 }
 
-func (d *deployer) selectEnvironment(forProject project, environmentName string) (*environment, error) {
+func (d *deployer) selectEnvironment(forProject *project, environmentName string) (*environment, error) {
 	environments, err := d.listEnvironments(forProject.Id)
 	if err != nil {
 		glog.V(1).Infof("list environments failed: %v", err)
@@ -145,16 +145,11 @@ func (d *deployer) Deploy(projectName, environmentName string) error {
 	}
 	version := versions[0]
 
-	environments, err := d.listEnvironments(selectedProject.Id)
+	environment, err := d.selectEnvironment(selectedProject, environmentName)
 	if err != nil {
-		glog.V(1).Infof("list environments failed: %v", err)
+		glog.V(1).Infof("environment selection failed: %v", err)
 		return err
 	}
-	if len(environments) == 0 {
-		glog.V(1).Infof("environment  list is empty")
-		return fmt.Errorf("environment  list is empty")
-	}
-	environment := environments[0]
 
 	err = d.deploy(environment.Id, version.Id)
 	if err != nil {

--- a/bamboo/bamboo_deployer.go
+++ b/bamboo/bamboo_deployer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"strings"
+
 	"github.com/bborbe/bot_agent_bamboo/model"
 	"github.com/bborbe/http/header"
 	"github.com/bborbe/http/rest"
@@ -69,7 +71,7 @@ func (d *deployer) selectProject(projectName string) (*project, error) {
 	}
 
 	filtered := filterProjects(projects, func(theProject project) bool {
-		return theProject.Name == projectName
+		return strings.HasPrefix(theProject.Name, projectName)
 	})
 
 	if len(filtered) == 0 {

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -43,6 +43,49 @@ func TestCreateAuth(t *testing.T) {
 
 const listProjectsJson = `[
   {
+    "id": 42,
+    "oid": 1154328879490400300,
+    "key": {
+      "key": "42"
+    },
+    "name": "Foo",
+    "planKey": {
+      "key": "TELU-TELUB"
+    },
+    "description": "",
+    "environments": [
+      {
+        "id": 2719745,
+        "key": {
+          "key": "2588673-2719745"
+        },
+        "name": "Staging",
+        "description": "",
+        "deploymentProjectId": 2588673,
+        "operations": {
+          "canView": true,
+          "canEdit": false,
+          "canDelete": false,
+          "allowedToExecute": false,
+          "canExecute": false,
+          "allowedToCreateVersion": false,
+          "allowedToSetVersionStatus": false
+        },
+        "position": 0,
+        "configurationState": "TASKED"
+      }
+    ],
+    "operations": {
+      "canView": true,
+      "canEdit": false,
+      "canDelete": false,
+      "allowedToExecute": false,
+      "canExecute": false,
+      "allowedToCreateVersion": false,
+      "allowedToSetVersionStatus": false
+    }
+  },
+  {
     "id": 2588673,
     "oid": 1154328879490400300,
     "key": {
@@ -963,6 +1006,23 @@ func TestFilterProject(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := AssertThat(selected.Id, Is(2588673)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFilterUnknwonProject(t *testing.T) {
+	d := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       createBody(listProjectsJson),
+		}, nil
+	}), "http://example.com", "user", "pass")
+
+	selected, err := d.selectProject("NotExistingProject")
+	if err := AssertThat(err, NotNilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(selected, NilValue()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -1053,7 +1053,7 @@ func TestEnqueeDeploy(t *testing.T) {
 			}
 			body = environmentsJson
 			environmentsRequestCount++
-		} else if req.URL.Path == "/rest/api/latest/queue/deployment/" && req.URL.Query().Get("environmentId") == "2719745" {
+		} else if req.URL.Path == "/rest/api/latest/queue/deployment/" && req.URL.Query().Get("environmentId") == "2719745" && req.URL.Query().Get("versionId") == "4685835" {
 			body = ""
 			queueDeploymentRequestCount++
 		} else {

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -1010,7 +1010,7 @@ func TestFilterProject(t *testing.T) {
 	}
 }
 
-func TestFilterUnknwonProject(t *testing.T) {
+func TestFilterUnknownProject(t *testing.T) {
 	d := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
 		return &http.Response{
 			StatusCode: 200,

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -1010,6 +1010,26 @@ func TestFilterProject(t *testing.T) {
 	}
 }
 
+func TestFilterProjectPrefix(t *testing.T) {
+	d := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       createBody(listProjectsJson),
+		}, nil
+	}), "http://example.com", "user", "pass")
+
+	selected, err := d.selectProject("Depl")
+	if err := AssertThat(err, NilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(selected, NotNilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(selected.Id, Is(2588673)); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFilterUnknownProject(t *testing.T) {
 	d := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
 		return &http.Response{

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -888,35 +888,6 @@ const versionsJson = `{
   "max-result": 15
 }`
 
-func TestListVersionsFailed(t *testing.T) {
-	deployer := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
-		return nil, fmt.Errorf("request failed")
-	}), "http://example.com", "user", "pass")
-	list, err := deployer.listVersions(2588673)
-	if err := AssertThat(err, NotNilValue()); err != nil {
-		t.Fatal(err)
-	}
-	if err := AssertThat(len(list), Is(0)); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestListVersionsSuccess(t *testing.T) {
-	deployer := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
-		return &http.Response{
-			StatusCode: 200,
-			Body:       createBody(versionsJson),
-		}, nil
-	}), "http://example.com", "user", "pass")
-	list, err := deployer.listVersions(2588673)
-	if err := AssertThat(err, NilValue()); err != nil {
-		t.Fatal(err)
-	}
-	if err := AssertThat(len(list), Is(15)); err != nil {
-		t.Fatal(err)
-	}
-}
-
 const environmentsJson = `{
   "id": 2588673,
   "oid": 1154328879490400300,
@@ -960,6 +931,35 @@ const environmentsJson = `{
     "allowedToSetVersionStatus": false
   }
 }`
+
+func TestListVersionsFailed(t *testing.T) {
+	deployer := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
+		return nil, fmt.Errorf("request failed")
+	}), "http://example.com", "user", "pass")
+	list, err := deployer.listVersions(2588673)
+	if err := AssertThat(err, NotNilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(len(list), Is(0)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListVersionsSuccess(t *testing.T) {
+	deployer := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       createBody(versionsJson),
+		}, nil
+	}), "http://example.com", "user", "pass")
+	list, err := deployer.listVersions(2588673)
+	if err := AssertThat(err, NilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(len(list), Is(15)); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestListEnvironmentsFailed(t *testing.T) {
 	deployer := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -947,7 +947,27 @@ func TestListEnvironmentsSuccess(t *testing.T) {
 	}
 }
 
-func TestEnqueeDeplos(t *testing.T) {
+func TestFilterProject(t *testing.T) {
+	d := NewDeployer(rest.New(func(req *http.Request) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       createBody(listProjectsJson),
+		}, nil
+	}), "http://example.com", "user", "pass")
+
+	selected, err := d.selectProject("Deploy Develop")
+	if err := AssertThat(err, NilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(selected, NotNilValue()); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(selected.Id, Is(2588673)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnqueeDeploy(t *testing.T) {
 	listProjectsRequestCount := 0
 	versionsRequestCount := 0
 	environmentsRequestCount := 0

--- a/bamboo/bamboo_deployer_test.go
+++ b/bamboo/bamboo_deployer_test.go
@@ -55,13 +55,13 @@ const listProjectsJson = `[
     "description": "",
     "environments": [
       {
-        "id": 2719745,
+        "id": 23,
         "key": {
-          "key": "2588673-2719745"
+          "key": "42-23"
         },
-        "name": "Staging",
+        "name": "Prod",
         "description": "",
-        "deploymentProjectId": 2588673,
+        "deploymentProjectId": 42,
         "operations": {
           "canView": true,
           "canEdit": false,
@@ -1041,19 +1041,19 @@ func TestEnqueeDeploy(t *testing.T) {
 		if req.URL.Path == "/rest/api/latest/deploy/project/all" {
 			body = listProjectsJson
 			listProjectsRequestCount++
-		} else if match, err := regexp.MatchString("^/rest/api/latest/deploy/project/[0-9]+/versions$", req.URL.Path); match {
+		} else if match, err := regexp.MatchString("^/rest/api/latest/deploy/project/2588673/versions$", req.URL.Path); match {
 			if err != nil {
 				t.Fatal(err)
 			}
 			body = versionsJson
 			versionsRequestCount++
-		} else if match, err := regexp.MatchString("^/rest/api/latest/deploy/project/[0-9]+$", req.URL.Path); match {
+		} else if match, err := regexp.MatchString("^/rest/api/latest/deploy/project/2588673$", req.URL.Path); match {
 			if err != nil {
 				t.Fatal(err)
 			}
 			body = environmentsJson
 			environmentsRequestCount++
-		} else if req.URL.Path == "/rest/api/latest/queue/deployment/" {
+		} else if req.URL.Path == "/rest/api/latest/queue/deployment/" && req.URL.Query().Get("environmentId") == "2719745" {
 			body = ""
 			queueDeploymentRequestCount++
 		} else {

--- a/deploy/deploy_handler.go
+++ b/deploy/deploy_handler.go
@@ -2,7 +2,6 @@ package message_handler
 
 import (
 	"fmt"
-	"strconv"
 
 	auth_model "github.com/bborbe/auth/model"
 	"github.com/bborbe/bot_agent/api"
@@ -29,7 +28,7 @@ func New(
 	d := new(handler)
 	d.deployer = deployer
 	d.hasRequiredGroups = hasRequiredGroups
-	d.command = command.New(prefix.String(), "[ID]")
+	d.command = command.New(prefix.String(), "[PROJECT]", "to", "[ENVIRONMENT]")
 	return d
 }
 
@@ -43,25 +42,21 @@ func (h *handler) Help(request *api.Request) []string {
 
 func (h *handler) HandleMessage(request *api.Request) ([]*api.Response, error) {
 	glog.V(3).Infof("handle deploy command")
-	id, err := h.command.Parameter(request, "[ID]")
+	projectName, err := h.command.Parameter(request, "[PROJECT]")
+	environmentName, err := h.command.Parameter(request, "[ENVIRONMENT]")
 	if err != nil {
 		glog.V(3).Infof("parse command failed: %v", err)
 		return nil, err
 	}
-	if err := h.deploy(id); err != nil {
+	if err := h.deploy(projectName, environmentName); err != nil {
 		return response.CreateReponseMessage(fmt.Sprintf("trigger deployment failed: %v", err)), nil
 	}
 	glog.V(2).Infof("return response")
 	return response.CreateReponseMessage("deployment triggered succcesful"), nil
 }
 
-func (h *handler) deploy(idString string) error {
-	id, err := strconv.Atoi(idString)
-	if err != nil {
-		glog.V(1).Infof("parse deployment id failed: %v", err)
-		return err
-	}
-	if err = h.deployer.Deploy(id); err != nil {
+func (h *handler) deploy(projectName, environmentName string) error {
+	if err := h.deployer.Deploy(projectName, environmentName); err != nil {
 		glog.V(1).Infof("deploy failed: %v", err)
 		return err
 	}

--- a/deploy/deploy_handler_test.go
+++ b/deploy/deploy_handler_test.go
@@ -18,13 +18,15 @@ func TestMain(m *testing.M) {
 }
 
 type mockDeployer struct {
-	counter int
-	number  int
-	result  error
+	counter     int
+	project     string
+	environment string
+	result      error
 }
 
-func (m *mockDeployer) Deploy(number int) error {
-	m.number = number
+func (m *mockDeployer) Deploy(project, environment string) error {
+	m.project = project
+	m.environment = environment
 	m.counter++
 	return m.result
 }
@@ -46,7 +48,7 @@ func TestMessageWithBamboo(t *testing.T) {
 		return true
 	})
 	responses, err := c.HandleMessage(&api.Request{
-		Message: "/deploy 123",
+		Message: "/deploy NiftyProject to Prod",
 	})
 	if err := AssertThat(err, NilValue()); err != nil {
 		t.Fatal(err)
@@ -63,7 +65,10 @@ func TestMessageWithBamboo(t *testing.T) {
 	if err := AssertThat(deployer.counter, Is(1)); err != nil {
 		t.Fatal(err)
 	}
-	if err := AssertThat(deployer.number, Is(123)); err != nil {
+	if err := AssertThat(deployer.project, Is("NiftyProject")); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(deployer.environment, Is("Prod")); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -75,7 +80,7 @@ func TestMessageWithBambooFailure(t *testing.T) {
 		return true
 	})
 	responses, err := c.HandleMessage(&api.Request{
-		Message: "/deploy 123",
+		Message: "/deploy NiftyProject to Prod",
 	})
 	if err := AssertThat(err, NilValue()); err != nil {
 		t.Fatal(err)
@@ -92,7 +97,10 @@ func TestMessageWithBambooFailure(t *testing.T) {
 	if err := AssertThat(deployer.counter, Is(1)); err != nil {
 		t.Fatal(err)
 	}
-	if err := AssertThat(deployer.number, Is(123)); err != nil {
+	if err := AssertThat(deployer.project, Is("NiftyProject")); err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertThat(deployer.environment, Is("Prod")); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
New command-syntax would be `/deploy NiftyProject to Prod``
Where `NiftyProject` is the name of a project and `Prod` the name of an Environment. It always deploy the last Version of that Project.

The Project-Name is matched by prefix, the Env-Name is matched for equallity